### PR TITLE
Uses the full path of dpkg-reconfigure.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class timezone($zone='UTC') {
   }
 
   exec { 'reconfigure-tzdata':
-    command     => 'dpkg-reconfigure -f noninteractive tzdata',
+    command     => '/usr/sbin/dpkg-reconfigure -f noninteractive tzdata',
     subscribe   => File['/etc/timezone'],
     require     => File['/etc/timezone'],
     refreshonly => true,


### PR DESCRIPTION
Hi Bram.

Thanks for sharing this module. Apparently it doesn't work, at least in Puppet 2.7.19, if the full path isn't provided. I get the error message:

> 'dpkg-reconfigure -f noninteractive tzdata' is not qualified and no path was specified. Please qualify the command or specify a path.

I tested it in Ubuntu Precise using Puppet 2.7.19/Ruby 1.8.

I've added the full path of `dpkg-reconfigure` and it worked fine.

Regards,

Vinícius
