### PR TITLE
Fixing warnings in Puppet 3.2.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@ class timezone($zone='UTC') {
   }
 
   file { '/etc/timezone':
-    content => inline_template('<%= zone + "\n" %>'),
+    content => inline_template('<%= @zone + "\n" %>'),
   }
 
   exec { 'reconfigure-tzdata':


### PR DESCRIPTION
Puppet 3.2.1 is complaining about the 'zone' variable as follows:

Warning: Variable access via 'zone' is deprecated. Use '@zone' instead. template[inline]:1
   (at (erb):1:in `result')

This patch eliminates the warning (tested against Puppet 3.2.1 only).
